### PR TITLE
use SPDX license identifier in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "../"
   ],
   "main": "google-youtube.html",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "homepage": "https://googlewebcomponents.github.io/google-youtube",
   "dependencies": {
     "google-apis": "GoogleWebComponents/google-apis#~0.3.2",


### PR DESCRIPTION
followup to GoogleWebComponents/style-guide#3

// @addyosmani 
