### PR TITLE
Add fluid resizing

### DIFF
--- a/google-youtube.html
+++ b/google-youtube.html
@@ -249,6 +249,7 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
        *
        * @attribute fluid
        * @type boolean
+       * @default false
        */
       fluid: false,
 


### PR DESCRIPTION
I took this from fitvids and fluidvid. If there is a `fluid` attribute set on the `google-youtube` element it will absolutely position and stretch the player to fill the parent container, while giving the parent container enough top padding to force the correct aspect ratio, even as the screen resizes.
