### PR TITLE
Exposes the setVolume, mute, and unMute methods of the underlying iFrame API

### DIFF
--- a/google-youtube.html
+++ b/google-youtube.html
@@ -292,6 +292,8 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
       /**
        * Modifies the volume of the current video.
        *
+       * Developers should take care not to break expected user experience by programatically modifying the volume on mobile browsers
+       * (note that the YouTube player, in addition, does not display volume controls in a mobile environment)
        * @method setVolume
        */      
       setVolume: function(v) {
@@ -303,6 +305,8 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
       /**
        * Mutes the current video.
        *
+       * Developers should take care not to break expected user experience by programatically modifying the volume on mobile browsers
+       * (note that the YouTube player, in addition, does not display volume controls in a mobile environment)
        * @method mute
        */        
       mute: function() {
@@ -314,6 +318,8 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
       /**
        * Unmutes the current video.
        *
+       * Developers should take care not to break expected user experience by programatically modifying the volume on mobile browsers
+       * (note that the YouTube player, in addition, does not display volume controls in a mobile environment)
        * @method unMute
        */        
       unMute: function() {
@@ -321,6 +327,7 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
           this.player.unMute();
         }
       },
+      
       /**
        * Pauses the current video.
        *


### PR DESCRIPTION
I needed these methods exposed for a project I'm working on, and thought that since I'd gone to the trouble (at least 5 minutes ... :)) of adding them in I might as well share them back; it's about as simple of a change as it gets but if you've got reasons that these volume methods weren't exposed before, no worries!
