### PR TITLE
Update google-youtube.html

### DIFF
--- a/google-youtube.html
+++ b/google-youtube.html
@@ -462,6 +462,7 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
       seekTo: function(seconds) {
         if (this.player && this.player.seekTo) {
           this.player.seekTo(seconds, true);
+          this.currenttime = Math.round(seconds);
         }
       },
 


### PR DESCRIPTION
When the video is paused "currenttime" was not updating components that were bound to "currenttime". The seek function of the component now sets "currenttime" to where the video was told to seek to.
