### PR TITLE
Call updatePlaybackStats() from within seekTo().

### DIFF
--- a/google-youtube.html
+++ b/google-youtube.html
@@ -462,6 +462,14 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
       seekTo: function(seconds) {
         if (this.player && this.player.seekTo) {
           this.player.seekTo(seconds, true);
+
+          // Explicitly call updatePlaybackStats() to ensure that the new playback info is
+          // reflected in the bound attributes.
+          // The 100ms delay is somewhat arbitrary, but the YouTube player does need time to
+          // update its internal state following the call to player.seekTo().
+          this.async(function() {
+            this.updatePlaybackStats();
+          }, null, 100);
         }
       },
 


### PR DESCRIPTION
This addresses an issue that @christurvey brought up in https://github.com/GoogleWebComponents/google-youtube/pull/19 in a slightly different manner.

It explicitly calls `updatePlaybackStats()` following a `player.seekTo()` after waiting for a small bit of time to give the YouTube player time to update its internal state.

(It would be lovely if there were some event-driven way to detect that the YouTube player's state had updated, but unfortunately that's not the case.)
