### PR TITLE
Adds a playbackstarted attribute

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "google-youtube",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "authors": [
     "Jeff Posnick <jeffy@google.com>"
   ],
@@ -24,8 +24,8 @@
   "license": "Apache-2.0",
   "homepage": "https://googlewebcomponents.github.io/google-youtube",
   "dependencies": {
-    "core-localstorage": "Polymer/core-localstorage#^0.5.1",
-    "google-apis": "GoogleWebComponents/google-apis#~0.4.2",
-    "polymer": "Polymer/polymer#^0.5.1"
+    "core-localstorage": "Polymer/core-localstorage#^0.5.4",
+    "google-apis": "GoogleWebComponents/google-apis#~0.4.3",
+    "polymer": "Polymer/polymer#^0.5.4"
   }
 }

--- a/google-youtube.html
+++ b/google-youtube.html
@@ -156,10 +156,10 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
        * This defaults to `false` and is set to `true` once the first 'playing' event is fired by
        * the underlying YouTube Player API.
        *
-       * Once set to `true`, it will remain that way until the 'ended' event is fired, or until
-       * a new video is cued/loaded, at which point it will reset to `false`.
+       * Once set to `true`, it will remain that way until a new video is cued/loaded,
+       * at which point it will reset to `false`.
        *
-       * Paused/buffering events won't cause `playbackstarted` to reset to `false`.
+       * Paused/buffering/ended events won't cause `playbackstarted` to reset to `false`.
        *
        * @attribute playbackstarted
        * @type boolean
@@ -501,7 +501,7 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
           this.pendingVideoId = this.videoid;
         } else {
           // Figure out whether we should cue or load (which will autoplay) the next video.
-          if (this.playsupported && this.autoplay === 1) {
+          if (this.playsupported && this.attributes['autoplay'].value == '1') {
             this.player.loadVideoById(this.videoid);
           } else {
             this.player.cueVideoById(this.videoid);
@@ -579,8 +579,8 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
                   this.updatePlaybackStatsInterval = null;
                 }
 
-                // -1: unstarted, 0: ended, 5: video cued
-                if (this.state <= 0 || this.state == 5) {
+                // state -1 is 'unstarted', and indicates that a new video has been cued.
+                if (this.state == -1) {
                   this.playbackstarted = false;
                 }
               }

--- a/google-youtube.html
+++ b/google-youtube.html
@@ -24,7 +24,7 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
 @homepage https://googlewebcomponents.github.io/google-youtube
 -->
 <polymer-element name="google-youtube"
-                 attributes="videoid playsupported state width height currenttime duration currenttimeformatted durationformatted fractionloaded chromeless thumbnail fluid">
+                 attributes="videoid playsupported state width height currenttime duration currenttimeformatted durationformatted fractionloaded chromeless thumbnail fluid playbackstarted">
   <template>
     <style>
       :host {
@@ -149,6 +149,23 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
        * @type boolean
        */
       playsupported: null,
+
+      /**
+       * Whether playback has started.
+       *
+       * This defaults to `false` and is set to `true` once the first 'playing' event is fired by
+       * the underlying YouTube Player API.
+       *
+       * Once set to `true`, it will remain that way until the 'ended' event is fired, or until
+       * a new video is cued/loaded, at which point it will reset to `false`.
+       *
+       * Paused/buffering events won't cause `playbackstarted` to reset to `false`.
+       *
+       * @attribute playbackstarted
+       * @type boolean
+       * @default false
+       */
+      playbackstarted: false,
 
       /**
        * Sets the height of the player on the page.
@@ -544,6 +561,8 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
               // The YouTube Player API only exposes playback data about a video once
               // playback has begun.
               if (this.state == 1) {
+                this.playbackstarted = true;
+
                 // After playback has begun, play() can always be used to resume playback if the video is paused.
                 this.playsupported = true;
 
@@ -558,6 +577,11 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
                 if (this.updatePlaybackStatsInterval) {
                   clearInterval(this.updatePlaybackStatsInterval);
                   this.updatePlaybackStatsInterval = null;
+                }
+
+                // -1: unstarted, 0: ended, 5: video cued
+                if (this.state <= 0 || this.state == 5) {
+                  this.playbackstarted = false;
                 }
               }
 

--- a/google-youtube.html
+++ b/google-youtube.html
@@ -156,10 +156,9 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
        * This defaults to `false` and is set to `true` once the first 'playing' event is fired by
        * the underlying YouTube Player API.
        *
-       * Once set to `true`, it will remain that way until a new video is cued/loaded,
-       * at which point it will reset to `false`.
-       *
+       * Once set to `true`, it will remain that way indefinitely.
        * Paused/buffering/ended events won't cause `playbackstarted` to reset to `false`.
+       * Nor will loading a new video into the player.
        *
        * @attribute playbackstarted
        * @type boolean
@@ -577,11 +576,6 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
                 if (this.updatePlaybackStatsInterval) {
                   clearInterval(this.updatePlaybackStatsInterval);
                   this.updatePlaybackStatsInterval = null;
-                }
-
-                // state -1 is 'unstarted', and indicates that a new video has been cued.
-                if (this.state == -1) {
-                  this.playbackstarted = false;
                 }
               }
 


### PR DESCRIPTION
@ebidel: Also bumps up Polymer dependencies to `0.5.4` and fixes a bug that caused the `videoidChanged` handler to cue instead of load a video when autoplay="1" was set.