### PR TITLE
Prevent null error on videoid change

### DIFF
--- a/google-youtube.html
+++ b/google-youtube.html
@@ -509,7 +509,7 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
           this.pendingVideoId = this.videoid;
         } else {
           // Figure out whether we should cue or load (which will autoplay) the next video.
-          if (this.playsupported && this.attributes['autoplay'].value == '1') {
+          if (this.playsupported && this.attributes['autoplay'] && this.attributes['autoplay'].value == '1') {
             this.player.loadVideoById(this.videoid);
           } else {
             this.player.cueVideoById(this.videoid);


### PR DESCRIPTION
Without checking for the existence of the `autoplay` attribute, this would error out halting the load entirely when you changed the `videoid` of the player without having autoplay enabled.