### PR TITLE
Move the element's <style> out of <template>

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description": "YouTube video playback web component.",
   "homepage": "https://googlewebcomponents.github.io/google-youtube",
   "main": "google-youtube.html",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "authors": [
     "Jeff Posnick <jeffy@google.com>"
   ],

--- a/google-youtube.html
+++ b/google-youtube.html
@@ -30,47 +30,47 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
 @demo
 -->
 <dom-module id="google-youtube">
- <template>
-    <style>
-      :host {
-        display: block;
-      }
+  <style>
+    :host {
+      display: block;
+    }
 
-      :host([fluid]) {
-        width: 100%;
-        max-width: 100%;
-        position: relative;
-      }
+    :host([fluid]) {
+      width: 100%;
+      max-width: 100%;
+      position: relative;
+    }
 
-      :host([fluid]) iframe,
-      :host([fluid]) #thumbnail {
-        vertical-align: bottom;
-        position: absolute;
-        top: 0px;
-        left: 0px;
-        width: 100%;
-        height: 100%;
-      }
+    :host([fluid]) iframe,
+    :host([fluid]) #thumbnail {
+      vertical-align: bottom;
+      position: absolute;
+      top: 0px;
+      left: 0px;
+      width: 100%;
+      height: 100%;
+    }
 
-      #container {
-        max-width: 100%;
-        max-height: 100%;
-      }
+    #container {
+      max-width: 100%;
+      max-height: 100%;
+    }
 
-      #thumbnail {
-        width: 100%;
-        height: 100%;
-        cursor: pointer;
-      }
+    #thumbnail {
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+    }
 
-      /* Some browsers will refuse to play videos with 'display: none' set, so position the video well offscreen instead. */
-      #playtest {
-        position: absolute;
-        top: -9999px;
-        left: -9999px;
-      }
-    </style>
+    /* Some browsers will refuse to play videos with 'display: none' set, so position the video well offscreen instead. */
+    #playtest {
+      position: absolute;
+      top: -9999px;
+      left: -9999px;
+    }
+  </style>
 
+  <template>
     <div id="container" style$="{{_computeContainerStyle(width, height)}}">
       <template is="dom-if" if="{{thumbnail}}">
         <img id="thumbnail"


### PR DESCRIPTION
R: @ebidel @addyosmani @atotic 

The element's `<style>` was inside of the `<template>`. That won't work as expected, at least not in Polymer 1.0. This moves the `<style>` to be a direct child of the `<dom-module>`.

Closes #40, which was broken because the styles needed for `fluid` weren't properly applied.

This also updates `bower.json` to the `1.1.2` release number, and I'll tag that release once this and https://github.com/GoogleWebComponents/google-youtube/pull/42 are merged.