### PR TITLE
videoid -> videoId in the demo

### DIFF
--- a/demo/demo.elements.html
+++ b/demo/demo.elements.html
@@ -100,7 +100,7 @@
       this.$.googleYouTube.pause();
     },
     handleCueVideo: function(ev) {
-      this.$.googleYouTube.videoid = this.$.videoId.value;
+      this.$.googleYouTube.videoId = this.$.videoId.value;
     }
   });
 


### PR DESCRIPTION
R: @addyosmani @ebidel @robdodson 

At one point, I think the property was `videoid`, but it's `videoId` now. The demo needs to be updated to match.