### PR TITLE
Prevents showing thumbnail and the video embed after changing the video ID

### DIFF
--- a/google-youtube.html
+++ b/google-youtube.html
@@ -539,6 +539,8 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
           this._player.cueVideoById(this.videoId);
         }
       }
+      
+      Polymer.dom(this.root).querySelector("#player").hidden = true;
     },
 
     _player: null,
@@ -652,7 +654,17 @@ The standard set of [YouTube player events](https://developers.google.com/youtub
     },
 
     _handleThumbnailTap: function() {
-      this.autoplay = 1;
+      if (!this._player) {
+        // Player isn't already initialized: flag to autoplay as soon as initialization is done
+        this.autoplay = 1;
+      } else {
+        // Player is already initialized: explicitly start playing
+        Polymer.dom(this.root).querySelector("#player").hidden = false;
+        if (this._player.playVideo && this.playsupported) {
+          this._player.playVideo();
+        }
+      }
+
       this.thumbnail = '';
     }
   });


### PR DESCRIPTION
The player is initialized when playing the video in the component for the first time. The fix explicitly hides the player when changing the video ID afterwards, and brings the player back once the user clicks again the thumbnail.

Fixes #46