### PR TITLE
Removed second argument from call to async

### DIFF
--- a/google-youtube.html
+++ b/google-youtube.html
@@ -570,7 +570,7 @@ Custom property | Description | Default
         // update its internal state following the call to player.seekTo().
         this.async(function() {
           this._updatePlaybackStats();
-        }, null, 100);
+        }, 100);
       }
     },
 


### PR DESCRIPTION
`async` from Polymer.Base now accepts 2 parameters. See the following:

* https://www.polymer-project.org/1.0/docs/api/Polymer.Base#method-async
* https://github.com/Polymer/polymer/blob/ff6e884ef4f309d41491333860a8bc9c2f178696/src/lib/async.html#L20
* https://github.com/Polymer/polymer/blob/f24dea115aeedefe0b8952c46451834836050d70/src/standard/utils.html#L271