### PR TITLE
Fixes the issue which broke playlist embedding functionality.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description": "YouTube video playback web component.",
   "homepage": "https://googlewebcomponents.github.io/google-youtube",
   "main": "google-youtube.html",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "authors": [
     "Jeff Posnick <jeffy@google.com>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description": "YouTube video playback web component.",
   "homepage": "https://googlewebcomponents.github.io/google-youtube",
   "main": "google-youtube.html",
-  "version": "1.2.2",
+  "version": "1.2.1",
   "authors": [
     "Jeff Posnick <jeffy@google.com>"
   ],

--- a/demo/demo.elements.html
+++ b/demo/demo.elements.html
@@ -66,6 +66,13 @@
                     height="480px"
                     thumbnail="//www.polymer-project.org/images/logos/p-logo.svg">
     </google-youtube>
+
+    <h3>Playlist Demo</h3>
+    <google-youtube list="PLNYkxOF6rcICc687SxHQRuo9TVNOJelSZ"
+                    list-type="playlist"
+                    width="640px"
+                    height="480px">
+    </google-youtube>
   </template>
 </dom-module>
 <script>

--- a/google-youtube.html
+++ b/google-youtube.html
@@ -150,7 +150,7 @@ Custom property | Description | Default
       },
 
       /**
-       * The list parameter, in conjunction with the listType parameter, identifies the content that will * load in the player.
+       * The list parameter, in conjunction with the listType parameter, identifies the content that will load in the player.
        * If the listType parameter value is search, then the list parameter value specifies the search query.
        * If the listType parameter value is user_uploads, then the list parameter value identifies the YouTube channel whose uploaded videos will be loaded.
        * If the listType parameter value is playlist, then the list parameter value specifies a YouTube playlist ID. In the parameter value, you need to prepend the playlist ID with the letters PL as shown in the example below.
@@ -159,7 +159,7 @@ Custom property | Description | Default
        */
       list: {
         type: String,
-        value: null
+        value: ''
       },
 
       /**
@@ -167,6 +167,9 @@ Custom property | Description | Default
        */
       listType: String,
 
+      /**
+       * Decides whether YouTube API should be loaded.
+       */
       shouldLoadApi: {
         type: Boolean,
         computed: '_computeShouldLoadApi(list, videoId)'

--- a/google-youtube.html
+++ b/google-youtube.html
@@ -88,7 +88,7 @@ Custom property | Description | Default
       </template>
 
       <template is="dom-if" if="{{!thumbnail}}">
-        <template is="dom-if" if="{{videoId}}">
+        <template is="dom-if" if="[[shouldLoadApi]]">
           <google-youtube-api on-api-load="_apiLoad"></google-youtube-api>
         </template>
       </template>
@@ -137,8 +137,8 @@ Custom property | Description | Default
        * to load a new video into the player (if `this.autoplay` is set to `1` and `playsupported` is true)
        * or cue a new video otherwise.
        *
-       * The underlying YouTube embed will not be added to the page unless this
-       * value is set.
+       * The underlying YouTube embed will not be added to the page unless
+       * `videoId` or `list` property is set.
        *
        * You can [search for videos programmatically](https://developers.google.com/youtube/v3/docs/search/list)
        * using the YouTube Data API, or just hardcode known video ids to display on your page.
@@ -147,6 +147,29 @@ Custom property | Description | Default
         type: String,
         value: '',
         observer: '_videoIdChanged'
+      },
+
+      /**
+       * The list parameter, in conjunction with the listType parameter, identifies the content that will * load in the player.
+       * If the listType parameter value is search, then the list parameter value specifies the search query.
+       * If the listType parameter value is user_uploads, then the list parameter value identifies the YouTube channel whose uploaded videos will be loaded.
+       * If the listType parameter value is playlist, then the list parameter value specifies a YouTube playlist ID. In the parameter value, you need to prepend the playlist ID with the letters PL as shown in the example below.
+       *
+       * See https://developers.google.com/youtube/player_parameters#list
+       */
+      list: {
+        type: String,
+        value: null
+      },
+
+      /**
+       * See https://developers.google.com/youtube/player_parameters#listtype
+       */
+      listType: String,
+
+      shouldLoadApi: {
+        type: Boolean,
+        computed: '_computeShouldLoadApi(list, videoId)'
       },
 
       /**
@@ -370,6 +393,10 @@ Custom property | Description | Default
 
     _computeContainerStyle: function(width, height) {
       return 'width:' + width + '; height:' + height;
+    },
+
+    _computeShouldLoadApi: function(videoId, list) {
+      return Boolean(videoId || list);
     },
 
     _useExistingPlaySupportedValue: function() {


### PR DESCRIPTION
<google-youtube-api> wouldn't load unless `videoId` property is provided. This commit allows to load YouTube API when either `videoId` or `list` property is set. `list` property allows to embed YouTube playlists.