### PR TITLE
Delete unknown JSDoc

### DIFF
--- a/google-youtube.js
+++ b/google-youtube.js
@@ -269,7 +269,6 @@ Polymer({
     *
     * You can divide the `currenttime` to determine the playback percentage.
     *
-    * @attribute duration
     * @type number
     */
     duration: {

--- a/google-youtube.js
+++ b/google-youtube.js
@@ -268,8 +268,6 @@ Polymer({
     * Exposes the video duration, in seconds.
     *
     * You can divide the `currenttime` to determine the playback percentage.
-    *
-    * @type number
     */
     duration: {
       type: Number,


### PR DESCRIPTION
Delete unknown and invalid JSDoc tags.
`@attribute` is unknown and `@type number` is missing `{}` around number. Both tags have no effect.